### PR TITLE
Improve script robustness

### DIFF
--- a/F95zone-Latest-Games-Images.user.js
+++ b/F95zone-Latest-Games-Images.user.js
@@ -31,8 +31,9 @@
 		log('handle');
 		$$('.resource-tile_gallery-wrap:not([data-lgi])').forEach(gallery=>{
 			gallery.setAttribute('data-lgi', 1);
-			const oldCur = $('.resource-tile_gallery-index');
-			oldCur.style.display = 'none';
+                        const oldCur = $('.resource-tile_gallery-index');
+                        if (!oldCur) return;
+                        oldCur.style.display = 'none';
 			const cur = document.createElement('span'); {
 				cur.textContent = '1';
 				oldCur.insertAdjacentElement('afterend', cur);
@@ -48,22 +49,22 @@
 				gallery.parentElement.append(marker);
 				markers.push(marker);
 			});
-			const moved = evt=>{
-				if (!gallery.parentElement) {
-					removeEventListener('mousemove', moved);
-					markers.forEach(it=>it.remove());
-					cur.remove();
-					return;
-				}
-				const rect = gallery.getBoundingClientRect();
-				const step = rect.width / imgs.length;
-				const idx = Math.floor((evt.x - rect.left) / step);
-				cur.textContent = idx+1;
-				imgs.forEach((img, i)=>{
-					img.classList[i==idx?'add':'remove']('f95-lgi--active');
-				});
-			};
-			addEventListener('mousemove', moved);
+                        const moved = evt=>{
+                                const rect = gallery.getBoundingClientRect();
+                                const step = rect.width / imgs.length;
+                                let idx = Math.floor((evt.x - rect.left) / step);
+                                idx = Math.max(0, Math.min(idx, imgs.length - 1));
+                                cur.textContent = idx+1;
+                                imgs.forEach((img, i)=>{
+                                        img.classList[i==idx?'add':'remove']('f95-lgi--active');
+                                });
+                        };
+                        const leave = () => {
+                                cur.textContent = '1';
+                                imgs.forEach(img => img.classList.remove('f95-lgi--active'));
+                        };
+                        gallery.addEventListener('mousemove', moved);
+                        gallery.addEventListener('mouseleave', leave);
 		});
 	});
 

--- a/F95zone-Latest-Games-Images.user.js
+++ b/F95zone-Latest-Games-Images.user.js
@@ -2,7 +2,7 @@
 // @name         F95Zone - Latest Games Images
 // @namespace    https://github.com/Prototyx5/
 // @downloadURL  https://github.com/Prototyx5/F95Zone-Latest-Games-Images/raw/refs/heads/main/F95zone-Latest-Games-Images.user.js
-// @version      1.2
+// @version      1.3
 // @description  Move mouse from left to right to navigate preview images on Latest Games page.
 // @author       LenAnderson
 // @match        https://f95zone.to/sam/latest_alpha/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # F95Zone - Latest Games Images
 Move mouse from left to right to navigate preview images on Latest Games page.
 
+This userscript highlights the current gallery image under the mouse cursor and
+displays an index counter. The script now ensures the index never drops below
+1 or exceeds the number of available images. It also resets the gallery when
+the mouse leaves to avoid stuck popups.
+
 
 ## Installation
 You need to have a UserScript extension (e.g. Tampermonkey for Chrome, Greasemonkey for Firefox) installed to run this script.


### PR DESCRIPTION
## Summary
- safeguard against missing index element
- prevent index from exceeding image bounds
- reset gallery state on mouse leave to avoid stuck popups
- document new handling behavior

## Testing
- `node --check F95zone-Latest-Games-Images.user.js`


------
https://chatgpt.com/codex/tasks/task_e_6848c664710c83248647a5d43c948ce6